### PR TITLE
feat/company-all-with-offset improve Get all companies without other information

### DIFF
--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -40,6 +40,32 @@ module Hubspot
         response['results'].map { |c| new(c) }
       end
 
+      # Find all companies by created date (descending)
+      #    recently_updated [boolean] (for querying all accounts by modified time)
+      #    count [Integer] for pagination
+      #    offset [Integer] for pagination
+      # {http://developers.hubspot.com/docs/methods/companies/get_companies_created}
+      # {http://developers.hubspot.com/docs/methods/companies/get_companies_modified}
+      # @return [Object], you can get:
+      # response.results for [Array]
+      # response.hasMore for [Boolean]
+      # response.offset for [Integer]
+      def all_with_offset(opts = {})
+        recently_updated = opts.delete(:recently_updated) { false }
+
+        path = if recently_updated
+          RECENTLY_MODIFIED_COMPANIES_PATH
+        else
+          RECENTLY_CREATED_COMPANIES_PATH
+        end
+
+        response = Hubspot::Connection.get_json(path, opts)
+        formatted_results = response['results'].map { |c| new(c) }
+        response = JSON.parse(response.to_json, object_class: OpenStruct)
+        response.results = formatted_results
+        response
+      end
+
       # Finds a list of companies by domain
       # {https://developers.hubspot.com/docs/methods/companies/search_companies_by_domain}
       # @param domain [String] company domain to search by

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -132,7 +132,7 @@ describe Hubspot::Contact do
         expect(last['name']).to eql 'Xge5rbdt2zm'
       end
 
-      it 'must filter only 2 copmanies' do
+      it 'must filter only 2 companies' do
         copmanies = Hubspot::Company.all(count: 2)
         expect(copmanies.size).to eql 2
       end

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -136,6 +136,30 @@ describe Hubspot::Contact do
         copmanies = Hubspot::Company.all(count: 2)
         expect(copmanies.size).to eql 2
       end
+
+      context 'all_with_offset' do
+        it 'should return companies with offset and hasMore' do
+          response = Hubspot::Company.all_with_offset
+          expect(response.results.size).to eq(20)
+
+          first = response.results.first
+          last = response.results.last
+
+          expect(first).to be_a Hubspot::Company
+          expect(first.vid).to eq(42866817)
+          expect(first['name']).to eql 'name'
+          expect(last).to be_a Hubspot::Company
+          expect(last.vid).to eql 42861017
+          expect(last['name']).to eql 'Xge5rbdt2zm'
+        end
+
+        it 'must filter only 2 companies' do
+          response = Hubspot::Company.all_with_offset(count: 2)
+          expect(response.results.size).to eq(2)
+          expect(response.hasMore).to be_truthy
+          expect(response.offset).to eq(2)
+        end
+      end
     end
 
     context 'recent companies' do


### PR DESCRIPTION
Add new method `#all_with_offset` to return not only results as response but also `hasMore` and `offset`, so it would be possible to get all companies. For instance

```ruby
response = Hubspot::Company.all_with_offset(count: 100)
while response.hasMore
  # DO SOMETHING
  response = Hubspot::Company.all_with_offset(count: 100, offset: response.offset)
end
```